### PR TITLE
Fix search by Add Streams

### DIFF
--- a/src/main/java/duke/TaskList.java
+++ b/src/main/java/duke/TaskList.java
@@ -1,6 +1,10 @@
 package duke;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.stream.Collectors;
 
 import duke.enums.Views;
 import duke.task.Task;
@@ -58,7 +62,14 @@ public class TaskList {
      * @return ArrayList of found task
      */
     public ArrayList<Task> search(String... query) {
-        ArrayList<Task> results = new ArrayList<Task>();
+        // Solution below adapted from https://stackoverflow.com/q/40605998
+        // Removes empty string from query
+        List<String> filteredList = Arrays.stream(query)
+                .filter(string -> !string.isEmpty())
+                .collect(Collectors.toList());
+        query = filteredList.toArray(new String[0]);
+
+        HashSet<Task> results = new HashSet<Task>();
         // Inefficient O(N^2) search method. Fix this whenever
         for (Task task : this.tasksList) {
             for (String word : query) {
@@ -67,7 +78,7 @@ public class TaskList {
                 }
             }
         }
-        return results;
+        return new ArrayList<Task>(results);
     }
 
     /**


### PR DESCRIPTION
When introducing varargs to search for tasks, two bugs were created:
1. Broken search results due to empty string that match .contains()
2. Duplicated results

To fix 1. streams is used to remove empty string from varargs

To fix 2. HashSet to ensure only unique item are added, converted to ArrayList afterwards to maintain compatibility with method return type

Solution was implemented with the help of Stackoverflow as Streams hard